### PR TITLE
Fix symbol crashes.  This pod conflicts with some other libraries

### DIFF
--- a/MGEvents/MGBlockWrapper.h
+++ b/MGEvents/MGBlockWrapper.h
@@ -2,14 +2,14 @@
 //  Created by matt on 24/08/12.
 //
 
-typedef void(^Block)();
-typedef void(^BlockWithContext)(id context);
+typedef void(^MGBlock)();
+typedef void(^MGBlockWithContext)(id context);
 
 @interface MGBlockWrapper : NSObject
 
-@property (nonatomic, copy) Block block;
+@property (nonatomic, copy) MGBlock block;
 
-+ (MGBlockWrapper *)wrapperForBlock:(Block)block;
++ (MGBlockWrapper *)wrapperForBlock:(MGBlock)block;
 - (void)doit;
 
 @end

--- a/MGEvents/MGBlockWrapper.m
+++ b/MGEvents/MGBlockWrapper.m
@@ -6,7 +6,7 @@
 
 @implementation MGBlockWrapper
 
-+ (MGBlockWrapper *)wrapperForBlock:(Block)block {
++ (MGBlockWrapper *)wrapperForBlock:(MGBlock)block {
   MGBlockWrapper *wrapper = [[MGBlockWrapper alloc] init];
   wrapper.block = block;
   return wrapper;

--- a/MGEvents/MGDeallocAction.h
+++ b/MGEvents/MGDeallocAction.h
@@ -6,6 +6,6 @@
 
 @interface MGDeallocAction : NSObject
 
-@property (nonatomic, copy) Block block;
+@property (nonatomic, copy) MGBlock block;
 
 @end

--- a/MGEvents/MGObserver.h
+++ b/MGEvents/MGObserver.h
@@ -7,9 +7,9 @@
 
 @interface MGObserver : NSObject
 
-@property (nonatomic, copy) Block block;
+@property (nonatomic, copy) MGBlock block;
 
 + (MGObserver *)observerFor:(NSObject *)object keypath:(NSString *)keypath
-    block:(Block)block;
+    block:(MGBlock)block;
 
 @end

--- a/MGEvents/MGObserver.m
+++ b/MGEvents/MGObserver.m
@@ -7,7 +7,7 @@
 @implementation MGObserver
 
 + (MGObserver *)observerFor:(NSObject *)object keypath:(NSString *)keypath
-    block:(Block)block {
+    block:(MGBlock)block {
   MGObserver *observer = [[MGObserver alloc] init];
   observer.block = block;
   [object addObserver:observer forKeyPath:keypath options:0 context:nil];

--- a/MGEvents/NSObject+MGEvents.h
+++ b/MGEvents/NSObject+MGEvents.h
@@ -21,13 +21,13 @@ When a custom event is triggered with the given name, perform the given block.
         NSLog(@"the earth has changed shape");
     }];
 */
-- (void)on:(NSString *)eventName do:(Block)handler;
+- (void)on:(NSString *)eventName do:(MGBlock)handler;
 
 /**
 * When a custom event is triggered with the given name, perform the given block
 * once. The block will not be performed on future triggering of the same event.
 */
-- (void)on:(NSString *)eventName doOnce:(Block)handler;
+- (void)on:(NSString *)eventName doOnce:(MGBlock)handler;
 
 /**
 When a custom event is triggered with the given name, perform the given block.
@@ -38,10 +38,10 @@ The block may potentially be provided a context object.
         NSLog(@"some details about the shape change: %@", context);
     }];
 */
-- (void)on:(NSString *)eventName doWithContext:(BlockWithContext)handler;
+- (void)on:(NSString *)eventName doWithContext:(MGBlockWithContext)handler;
 
-- (void)when:(id)object does:(NSString *)eventName do:(Block)handler;
-- (void)when:(id)object does:(NSString *)eventName doWithContext:(BlockWithContext)handler;
+- (void)when:(id)object does:(NSString *)eventName do:(MGBlock)handler;
+- (void)when:(id)object does:(NSString *)eventName doWithContext:(MGBlockWithContext)handler;
 
 /** @name Custom event triggering */
 
@@ -70,7 +70,7 @@ On change of the given keypath, perform the given block.
         NSLog(@"my selected state changed to: %@", box.selected ? @"ON" : @"OFF");
     }];
 */
-- (void)onChangeOf:(NSString *)keypath do:(Block)block;
+- (void)onChangeOf:(NSString *)keypath do:(MGBlock)block;
 
 /**
 On change of any of the given keypaths, perform the given block.
@@ -80,8 +80,8 @@ On change of any of the given keypaths, perform the given block.
         NSLog(@"my highlighted state is: %@", box.highlighted ? @"ON" : @"OFF");
     }];
 */
-- (void)onChangeOfAny:(NSArray *)keypaths do:(Block)block;
+- (void)onChangeOfAny:(NSArray *)keypaths do:(MGBlock)block;
 
-@property (nonatomic, copy) Block onDealloc;
+@property (nonatomic, copy) MGBlock onDealloc;
 
 @end

--- a/MGEvents/NSObject+MGEvents.m
+++ b/MGEvents/NSObject+MGEvents.m
@@ -27,7 +27,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
 }
 
 - (void)on:(NSString *)eventName doWithContext:(MGBlockWithContext)handler {
-  [self on:eventName do:(Block)handler once:NO context:YES];
+  [self on:eventName do:(MGBlock)handler once:NO context:YES];
 }
 
 - (void)on:(NSString *)eventName do:(MGBlock)handler once:(BOOL)once
@@ -53,7 +53,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
 }
 
 - (void)when:(id)object does:(NSString *)eventName doWithContext:(MGBlockWithContext)handler {
-    [self when:object does:eventName do:(Block)handler context:YES];
+    [self when:object does:eventName do:(MGBlock)handler context:YES];
 }
 
 - (void)when:(NSObject *)object does:(NSString *)eventName do:(MGBlock)handler

--- a/MGEvents/NSObject+MGEvents.m
+++ b/MGEvents/NSObject+MGEvents.m
@@ -18,19 +18,19 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
 
 #pragma mark - Custom events
 
-- (void)on:(NSString *)eventName do:(Block)handler {
+- (void)on:(NSString *)eventName do:(MGBlock)handler {
   [self on:eventName do:handler once:NO context:NO];
 }
 
-- (void)on:(NSString *)eventName doOnce:(Block)handler {
+- (void)on:(NSString *)eventName doOnce:(MGBlock)handler {
   [self on:eventName do:handler once:YES context:NO];
 }
 
-- (void)on:(NSString *)eventName doWithContext:(BlockWithContext)handler {
+- (void)on:(NSString *)eventName doWithContext:(MGBlockWithContext)handler {
   [self on:eventName do:(Block)handler once:NO context:YES];
 }
 
-- (void)on:(NSString *)eventName do:(Block)handler once:(BOOL)once
+- (void)on:(NSString *)eventName do:(MGBlock)handler once:(BOOL)once
    context:(BOOL)isContextBlock {
 
   // get all handlers for this event type
@@ -48,15 +48,15 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
   }
 }
 
-- (void)when:(id)object does:(NSString *)eventName do:(Block)handler {
+- (void)when:(id)object does:(NSString *)eventName do:(MGBlock)handler {
     [self when:object does:eventName do:handler context:NO];
 }
 
-- (void)when:(id)object does:(NSString *)eventName doWithContext:(BlockWithContext)handler {
+- (void)when:(id)object does:(NSString *)eventName doWithContext:(MGBlockWithContext)handler {
     [self when:object does:eventName do:(Block)handler context:YES];
 }
 
-- (void)when:(NSObject *)object does:(NSString *)eventName do:(Block)handler
+- (void)when:(NSObject *)object does:(NSString *)eventName do:(MGBlock)handler
       context:(BOOL)isContextBlock {
 
     // get the proxy handlers array
@@ -100,10 +100,10 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
             continue;
         }
         if (handlerDict[@"blockWithContext"]) {
-            BlockWithContext block = handlerDict[@"blockWithContext"];
+            MGBlockWithContext block = handlerDict[@"blockWithContext"];
             block(context);
         } else if (handlerDict[@"block"]) {
-            Block block = handlerDict[@"block"];
+            MGBlock block = handlerDict[@"block"];
             block();
         }
         if ([handlerDict[@"once"] boolValue]) {
@@ -114,7 +114,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
 
 #pragma mark - Property observing
 
-- (void)onChangeOf:(NSString *)keypath do:(Block)block {
+- (void)onChangeOf:(NSString *)keypath do:(MGBlock)block {
 
   // get observers for this keypath
   NSMutableArray *observers = self.MGObservers[keypath];
@@ -127,7 +127,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
   // make and store an observer
   MGObserver *observer = [MGObserver observerFor:self keypath:keypath block:block];
   [observers addObject:observer];
-    
+
   __unsafe_unretained id _self = self;
   __unsafe_unretained id _observer = observer;
   observer.onDealloc = ^{
@@ -135,7 +135,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
   };
 }
 
-- (void)onChangeOfAny:(NSArray *)keypaths do:(Block)block {
+- (void)onChangeOfAny:(NSArray *)keypaths do:(MGBlock)block {
   for (NSString *keypath in keypaths) {
     [self onChangeOf:keypath do:block];
   }
@@ -161,7 +161,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
   return observers;
 }
 
-- (Block)onDealloc {
+- (MGBlock)onDealloc {
   MGDeallocAction *wrapper = objc_getAssociatedObject(self, MGDeallocActionKey);
   return wrapper.block;
 }
@@ -178,7 +178,7 @@ static char *MGDeallocActionKey = "MGDeallocActionKey";
       OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)setOnDealloc:(Block)block {
+- (void)setOnDealloc:(MGBlock)block {
   MGDeallocAction *wrapper = objc_getAssociatedObject(self, MGDeallocActionKey);
   if (!wrapper) {
     wrapper = MGDeallocAction.new;

--- a/MGEvents/UIControl+MGEvents.h
+++ b/MGEvents/UIControl+MGEvents.h
@@ -19,7 +19,7 @@ When a control event is triggered of the given kind, perform the given block.
         NSLog(@"i've been tapped!");
     }];
 */
-- (void)onControlEvent:(UIControlEvents)controlEvent do:(Block)handler;
+- (void)onControlEvent:(UIControlEvents)controlEvent do:(MGBlock)handler;
 
 /**
 * Remove all event handlers for the given control event.

--- a/MGEvents/UIControl+MGEvents.m
+++ b/MGEvents/UIControl+MGEvents.m
@@ -9,7 +9,7 @@ static char *MGEventHandlersKey = "MGEventHandlersKey";
 
 @implementation UIControl (MGEvents)
 
-- (void)onControlEvent:(UIControlEvents)controlEvent do:(Block)handler {
+- (void)onControlEvent:(UIControlEvents)controlEvent do:(MGBlock)handler {
 
   // get all handlers for this control event
   NSMutableArray *handlers = self.MGEventHandlers[@((int)controlEvent)];


### PR DESCRIPTION
I was getting symbol clashes for `Block` and `BlockContext` so I renamed those classes to `MGBlock` and `MGBlockContext`.
